### PR TITLE
Added ability to set alias for root table of sql query and sql command exists and not exists.

### DIFF
--- a/src/main/java/com/avaje/ebean/ExpressionFactory.java
+++ b/src/main/java/com/avaje/ebean/ExpressionFactory.java
@@ -169,6 +169,16 @@ public interface ExpressionFactory {
    * In - property has a value in the collection of values.
    */
   public Expression in(String propertyName, Collection<?> values);
+  
+  /**
+   * Exists expression
+   */
+  public Expression exists(Query<?> subQuery);
+  
+  /**
+   * Not exists expression
+   */
+  public Expression notExists(Query<?> subQuery);
 
   /**
    * Id Equal to - ID property is equal to the value.

--- a/src/main/java/com/avaje/ebean/ExpressionList.java
+++ b/src/main/java/com/avaje/ebean/ExpressionList.java
@@ -473,6 +473,16 @@ public interface ExpressionList<T> extends Serializable {
    * In - property has a value in the collection of values.
    */
   public ExpressionList<T> in(String propertyName, Collection<?> values);
+  
+  /**
+   * Exists expression
+   */
+  public ExpressionList<T> exists(Query<?> subQuery);
+  
+  /**
+   * Not exists expression
+   */
+  public ExpressionList<T> notExists(Query<?> subQuery);
 
   /**
    * Id IN a list of id values.

--- a/src/main/java/com/avaje/ebean/Query.java
+++ b/src/main/java/com/avaje/ebean/Query.java
@@ -1230,4 +1230,9 @@ public interface Query<T> extends Serializable {
    * Return true if this query has forUpdate set.
    */
   public boolean isForUpdate();
+  
+  /**
+   * Set root table alias.
+   */
+  public Query<T> alias(String alias);
 }

--- a/src/main/java/com/avaje/ebeaninternal/api/SpiQuery.java
+++ b/src/main/java/com/avaje/ebeaninternal/api/SpiQuery.java
@@ -611,4 +611,9 @@ public interface SpiQuery<T> extends Query<T> {
      * Return true if this query has been cancelled.
      */
     public boolean isCancelled();
+    
+    /**
+     * Return root table alias set by {@link #alias(String)} command.
+     */
+    public String getAlias();
 }

--- a/src/main/java/com/avaje/ebeaninternal/server/expression/DefaultExpressionFactory.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/expression/DefaultExpressionFactory.java
@@ -241,6 +241,23 @@ public class DefaultExpressionFactory implements SpiExpressionFactory {
   public Expression in(String propertyName, Collection<?> values) {
     return new InExpression(propertyName, values);
   }
+  
+  /**
+   * Exists subquery 
+   */
+  @Override
+  public Expression exists(Query<?> subQuery) {
+	return new ExistsExpression((SpiQuery<?>) subQuery, false);
+  }
+  
+  /**
+   * Not exists subquery 
+   */
+  @Override
+  public Expression notExists(Query<?> subQuery) {
+	return new ExistsExpression((SpiQuery<?>) subQuery, true);
+  }
+
 
   /**
    * Id Equal to - ID property is equal to the value.

--- a/src/main/java/com/avaje/ebeaninternal/server/expression/ExistsExpression.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/expression/ExistsExpression.java
@@ -1,0 +1,87 @@
+package com.avaje.ebeaninternal.server.expression;
+
+import java.util.List;
+
+import com.avaje.ebean.event.BeanQueryRequest;
+import com.avaje.ebeaninternal.api.HashQueryPlanBuilder;
+import com.avaje.ebeaninternal.api.ManyWhereJoins;
+import com.avaje.ebeaninternal.api.SpiEbeanServer;
+import com.avaje.ebeaninternal.api.SpiExpression;
+import com.avaje.ebeaninternal.api.SpiExpressionRequest;
+import com.avaje.ebeaninternal.api.SpiQuery;
+import com.avaje.ebeaninternal.server.deploy.BeanDescriptor;
+import com.avaje.ebeaninternal.server.query.CQuery;
+
+public class ExistsExpression implements SpiExpression {
+
+	  private static final long serialVersionUID = 666990277309851644L;
+
+	  private final boolean not;
+	  private final SpiQuery<?> subQuery;
+
+	  private transient CQuery<?> compiledSubQuery;
+
+	  public ExistsExpression(SpiQuery<?> subQuery, boolean not) {
+	    this.subQuery = subQuery;
+	    this.not=not;
+	  }
+
+	  public void queryAutoFetchHash(HashQueryPlanBuilder builder) {
+	    builder.add(ExistsExpression.class).add(not);
+	    
+	    subQuery.queryAutofetchHash(builder);
+	  }
+
+	  public void queryPlanHash(BeanQueryRequest<?> request, HashQueryPlanBuilder builder) {
+
+	    // queryPlanHash executes prior to addSql() or addBindValues()
+	    // ... so compiledQuery will exist
+	    compiledSubQuery = compileSubQuery(request);
+
+	    queryAutoFetchHash(builder);
+	  }
+
+	  /**
+	   * Compile/build the sub query.
+	   */
+	  private CQuery<?> compileSubQuery(BeanQueryRequest<?> queryRequest) {
+
+	    SpiEbeanServer ebeanServer = (SpiEbeanServer) queryRequest.getEbeanServer();
+	    return ebeanServer.compileQuery(subQuery, queryRequest.getTransaction());
+	  }
+
+	  public int queryBindHash() {
+	    return subQuery.queryBindHash();
+	  }
+
+	  public void addSql(SpiExpressionRequest request) {
+
+	    String subSelect = compiledSubQuery.getGeneratedSql();
+	    subSelect = subSelect.replace('\n', ' ');
+
+
+	    if(not) request.append(" not");
+	    request.append(" exists (");
+	    request.append(subSelect);
+	    request.append(") ");
+	  }
+
+	  public void addBindValues(SpiExpressionRequest request) {
+
+	    List<Object> bindParams = compiledSubQuery.getPredicates().getWhereExprBindValues();
+
+	    if (bindParams == null) {
+	      return;
+	    }
+
+	    for (int i = 0; i < bindParams.size(); i++) {
+	      request.addBindValue(bindParams.get(i));
+	    }
+	  }
+
+	@Override
+	public void containsMany(BeanDescriptor<?> desc, ManyWhereJoins whereManyJoins) {
+		// TODO Auto-generated method stub
+		
+	}
+}

--- a/src/main/java/com/avaje/ebeaninternal/server/expression/JunctionExpression.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/expression/JunctionExpression.java
@@ -361,6 +361,16 @@ abstract class JunctionExpression<T> implements Junction<T>, SpiExpression, Expr
   public ExpressionList<T> in(String propertyName, com.avaje.ebean.Query<?> subQuery) {
     return exprList.in(propertyName, subQuery);
   }
+  
+  @Override
+  public ExpressionList<T> exists(Query<?> subQuery) {
+	return exprList.exists(subQuery);
+  }
+  
+  @Override
+  public ExpressionList<T> notExists(Query<?> subQuery) {
+	return exprList.exists(subQuery);
+  }
 
   @Override
   public ExpressionList<T> isNotNull(String propertyName) {

--- a/src/main/java/com/avaje/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -104,7 +104,7 @@ public class SqlTreeBuilder {
     this.queryDetail = query.getDetail();
 
     this.predicates = predicates;
-    this.alias = new SqlTreeAlias(request.getBeanDescriptor().getBaseTableAlias());
+    this.alias = new SqlTreeAlias(request.getQuery().getAlias()==null?request.getBeanDescriptor().getBaseTableAlias():request.getQuery().getAlias());
     this.ctx = new DefaultDbSqlContext(alias, tableAliasPlaceHolder, columnAliasPrefix, !subQuery);
   }
 

--- a/src/main/java/com/avaje/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -190,6 +190,11 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
   private boolean autoFetchTuned;
 
   private boolean logSecondaryQuery;
+  
+  /**
+   * Root table alias. For {@link Query#alias(String)} command.
+   */
+  private String rootTableAlias=null;
 
   /**
    * The node of the bean or collection that fired lazy loading. Not null if profiling is on and
@@ -680,6 +685,7 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
     builder.add(id != null);
     builder.add(rawSql == null ? 0 : rawSql.queryHash());
     builder.add(includeTableJoin != null ? includeTableJoin.queryHash() : 0);
+    builder.add(rootTableAlias);
 
     if (detail != null) {
       detail.queryPlanHash(request, builder);
@@ -1283,6 +1289,17 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
     synchronized (this) {
       this.cancelableQuery = cancelableQuery;
     }
+  }
+  
+  @Override
+  public Query<T> alias(String alias) {
+	  this.rootTableAlias=alias;
+	  return this;
+  }
+  
+  @Override
+  public String getAlias() {
+    return rootTableAlias;
   }
 
   public void cancel() {

--- a/src/main/java/com/avaje/ebeaninternal/util/DefaultExpressionList.java
+++ b/src/main/java/com/avaje/ebeaninternal/util/DefaultExpressionList.java
@@ -468,6 +468,19 @@ public class DefaultExpressionList<T> implements SpiExpressionList<T> {
     add(expr.in(propertyName, values));
     return this;
   }
+  
+  @Override
+  public ExpressionList<T> exists(Query<?> subQuery) {
+	add(expr.exists(subQuery));
+	return this;
+  }
+  
+  @Override
+  public ExpressionList<T> notExists(Query<?> subQuery) {
+	add(expr.notExists(subQuery));
+	return this;
+  }
+
 
   @Override
   public ExpressionList<T> isNotNull(String propertyName) {

--- a/src/test/java/com/avaje/tests/query/TestQueryAlias.java
+++ b/src/test/java/com/avaje/tests/query/TestQueryAlias.java
@@ -1,0 +1,35 @@
+package com.avaje.tests.query;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.avaje.ebean.BaseTestCase;
+import com.avaje.ebean.Ebean;
+import com.avaje.ebean.Query;
+import com.avaje.tests.model.basic.CKeyParent;
+import com.avaje.tests.model.basic.ResetBasicData;
+
+public class TestQueryAlias extends BaseTestCase {
+	@Test
+	public void testExists() {
+		ResetBasicData.reset();
+		
+	    Query<CKeyParent> sq = Ebean.createQuery(CKeyParent.class).select("id.oneKey").alias("st0")
+	            .setAutofetch(false).where().query();
+
+	        Query<CKeyParent> pq = Ebean.find(CKeyParent.class).alias("myt0").where().in("id.oneKey", sq).query();
+
+	        pq.findList();
+
+	        String sql = pq.getGeneratedSql();
+	        
+	        System.out.println(sql);
+	        // Without alias command is should be:
+	        // select t0.one_key c0, t0.two_key c1, t0.name c2, t0.version c3, t0.assoc_id c4 from ckey_parent t0 where  (t0.one_key) in (select t0.one_key from ckey_parent t0)
+	        // but with alias command SQL should look like this:
+	        // select myt0.one_key c0, myt0.two_key c1, myt0.name c2, myt0.version c3, myt0.assoc_id c4 from ckey_parent myt0 where  (myt0.one_key) in (select st0.one_key from ckey_parent st0) 
+	        
+	        Assert.assertTrue(sql.indexOf("ckey_parent myt0")>0);
+	        Assert.assertTrue(sql.indexOf("in (select st0.one_key from ckey_parent st0)")>0);
+	}
+}

--- a/src/test/java/com/avaje/tests/query/TestQueryExists.java
+++ b/src/test/java/com/avaje/tests/query/TestQueryExists.java
@@ -1,0 +1,41 @@
+package com.avaje.tests.query;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.avaje.ebean.BaseTestCase;
+import com.avaje.ebean.Ebean;
+import com.avaje.ebean.Query;
+import com.avaje.tests.model.basic.Customer;
+import com.avaje.tests.model.basic.Order;
+import com.avaje.tests.model.basic.ResetBasicData;
+
+public class TestQueryExists extends BaseTestCase {
+	@Test
+	public void testExists() {
+		ResetBasicData.reset();
+
+		Query<Order> subQuery=Ebean.find(Order.class).alias("sq").select("id").where().raw("sq.kcustomer_id = qt.id")
+				.query();
+		Query<Customer> query=Ebean.find(Customer.class).alias("qt").where().exists(subQuery).query();
+
+		query.findList();
+		String sql=query.getGeneratedSql();
+
+		Assert.assertTrue(sql.indexOf("exists (")>0);
+	}
+
+	@Test
+	public void testNotExists() {
+		ResetBasicData.reset();
+
+		Query<Order> subQuery=Ebean.find(Order.class).alias("sq").select("id").where().raw("sq.kcustomer_id = qt.id")
+				.query();
+		Query<Customer> query=Ebean.find(Customer.class).alias("qt").where().notExists(subQuery).query();
+
+		query.findList();
+		String sql=query.getGeneratedSql();
+
+		Assert.assertTrue(sql.indexOf("not exists (")>0);
+	}
+}


### PR DESCRIPTION
I have added to query (Query) additional command to set root table (SqlTreeAlias#rootTableAlias).

I can be very usefull when using subqueries for example:
```java
	    Query<CKeyParent> sq = Ebean.createQuery(CKeyParent.class).select("version").alias("st0")
	            .setAutofetch(false).where().raw("st0.version = myt0.version").query();

	        Query<CKeyParent> pq = Ebean.find(CKeyParent.class).alias("myt0").where().in("version",sq).query();
```
will generate:
```sql
select 
    myt0.one_key c0, myt0.two_key c1, myt0.name c2, myt0.version c3, myt0.assoc_id c4 
from 
    ckey_parent myt0 
where  
    (myt0.version) in (select st0.version from ckey_parent st0 where st0.version = myt0.version) 
```
(I know that above query has no sense)
