### PR TITLE
Fix issue #259

### DIFF
--- a/src/main/java/com/avaje/ebeaninternal/server/query/CQueryPredicates.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/query/CQueryPredicates.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.avaje.ebean.RawSql;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -234,7 +235,8 @@ public class CQueryPredicates {
           // RawSql query hit cached query plan. Need to convert
           // named parameters into positioned parameters so that
           // the named parameters are bound
-          String s = query.getRawSql().getSql().getPreWhere();
+          RawSql.Sql sql = query.getRawSql().getSql();
+          String s = sql.isParsed() ? sql.getPreWhere() : sql.getUnparsedSql();
           if (bindParams.requiresNamedParamsPrepare()) {
             BindParamsParser.parse(bindParams, s);
           }

--- a/src/test/java/com/avaje/tests/rawsql/TestRawSqlUnparsedQuery.java
+++ b/src/test/java/com/avaje/tests/rawsql/TestRawSqlUnparsedQuery.java
@@ -1,0 +1,37 @@
+package com.avaje.tests.rawsql;
+
+import com.avaje.ebean.*;
+import com.avaje.tests.model.basic.Customer;
+import com.avaje.tests.model.basic.ResetBasicData;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class TestRawSqlUnparsedQuery extends BaseTestCase {
+
+    @Test
+    public void testDoubleUnparsedQuery() {
+
+        // Checks for RawSql caching issue https://github.com/ebean-orm/avaje-ebeanorm/issues/259
+        ResetBasicData.reset();
+
+        test();
+        test();
+    }
+
+    private static void test() {
+        RawSql rawSql = RawSqlBuilder
+                .unparsed("select r.id, r.name from o_customer r where r.id >= :a and r.name like :b")
+                .columnMapping("r.id", "id").columnMapping("r.name", "name").create();
+
+        Query<Customer> query = Ebean.find(Customer.class);
+        query.setRawSql(rawSql);
+        query.setParameter("a", 1);
+        query.setParameter("b", "R%");
+
+        List<Customer> list = query.findList();
+        Assert.assertNotNull(list);
+    }
+
+}


### PR DESCRIPTION
New code doesn't use `getPreWhere` in case of unparsed SQL (because `preWhere` is never defined for an unparsed SQL).

~~If you want me to contribute also a test case then please could you shortly introduce me to a testing system - there's a lot of test code, I don't know how it is organized.~~ _(**UPD:** There is a test case now.)_

Please see a description and comments in #259 for some explanation. There's a separate test project also (it can be easily converted to a proper test case I hope): https://github.com/ForNeVeR/ebean-issue-259