### PR TITLE
Ability to run maven tests with diffrent databases.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,13 @@
             <include>**/*Test.java</include>
             <include>**/*Tests.java</include>
           </includes>
+          <systemProperties>
+            <property>
+              <!-- transfer datasource.default parameter -->
+              <name>datasource.default</name>
+              <value>${datasource.default}</value>
+            </property>
+          </systemProperties>
         </configuration>
       </plugin>
  	 <plugin>

--- a/src/main/java/com/avaje/ebean/PrimaryServer.java
+++ b/src/main/java/com/avaje/ebean/PrimaryServer.java
@@ -46,7 +46,13 @@ class PrimaryServer {
     if (globalProperties == null) {
       globalProperties = PropertyMap.defaultProperties();
     }
-    defaultServerName = globalProperties.getProperty("datasource.default");
+    defaultServerName = System.getProperty("datasource.default");
+    if(defaultServerName == null) {
+      defaultServerName = System.getProperty("ebean.default.datasource");
+    }
+    if(defaultServerName == null) {
+      defaultServerName = globalProperties.getProperty("datasource.default");
+    }
     if (defaultServerName == null) {
       defaultServerName = globalProperties.getProperty("ebean.default.datasource");
     }


### PR DESCRIPTION
I have created patch (2 commits) which allowa to select default database for testing.

First commit just adds option to override default datasource from java property:
```sh
java -Ddatasource.default=mysql ...
java -Debean.default.datasource=mysql ...
```
The second commit just transfers maven argument to junit tests and you can run:
```sh
mvn -Ddatasource.default=mysql
```
to test with mysql or any other configured database in ebean.properties file.