### PR TITLE
Backport fix for #154 - @OrderBy on a @OneToMany property is not used when lazy loading

### DIFF
--- a/src/main/java/com/avaje/ebeaninternal/server/core/DefaultBeanLoader.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/core/DefaultBeanLoader.java
@@ -107,7 +107,10 @@ public class DefaultBeanLoader {
     BeanDescriptor<?> desc = ctx.getBeanDescriptor();
 
     SpiQuery<?> query = (SpiQuery<?>) server.createQuery(many.getTargetType());
-
+    String orderBy = many.getLazyFetchOrderBy();
+    if (orderBy != null) {
+      query.orderBy(orderBy);
+    }
     query.setLazyLoadForParents(idList, many);
     many.addWhereParentIdIn(query, idList);
 

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/BeanPropertyAssocMany.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/BeanPropertyAssocMany.java
@@ -54,9 +54,17 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> {
 	 */
 	final boolean manyToMany;
 
-	final String fetchOrderBy;
+  /**
+   * Order by used when fetch joining the associated many.
+   */
+  private final String fetchOrderBy;
 
-	final String mapKey;
+  /**
+   * Order by used when lazy loading the associated many.
+   */
+  private String lazyFetchOrderBy;
+
+  private final String mapKey;
 
 	/**
 	 * The type of the many, set, list or map.
@@ -132,6 +140,22 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> {
 			exportedProperties = createExported();
 			if (exportedProperties.length > 0){
 				embeddedExportedProperties = exportedProperties[0].isEmbedded();
+
+				if (fetchOrderBy != null) {
+  				// derive lazyFetchOrderBy
+  				StringBuilder sb = new StringBuilder(50);
+  	      for (int i = 0; i < exportedProperties.length; i++) {
+  	        if (i > 0) {
+  	          sb.append(", ");
+  	        }
+  	        // these fkcolumns always on base table hence t0 as alias
+  	        sb.append("t0.").append(exportedProperties[i].getForeignDbColumn()); 
+  	      }
+  	      if (fetchOrderBy != null) {
+  	        sb.append(", ").append(fetchOrderBy);
+  	      }
+  	      lazyFetchOrderBy = sb.toString().trim();
+				}
 			}
 			
 			String delStmt;
@@ -462,6 +486,13 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> {
 	}
 
 	/**
+	 * Return the order by for use when lazy loading the associated collection.
+	 */
+	public String getLazyFetchOrderBy() {
+    return lazyFetchOrderBy;
+  }
+
+  /**
 	 * Return the default mapKey when returning a Map.
 	 */
 	public String getMapKey() {

--- a/src/test/java/com/avaje/tests/basic/TestSharedInstancePropagation.java
+++ b/src/test/java/com/avaje/tests/basic/TestSharedInstancePropagation.java
@@ -2,8 +2,7 @@ package com.avaje.tests.basic;
 
 import java.util.List;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.avaje.ebean.BaseTestCase;
@@ -25,6 +24,8 @@ public class TestSharedInstancePropagation extends BaseTestCase {
 
 		ResetBasicData.reset();
 		
+		Ebean.getServerCacheManager().clearAll();
+
 		Order order = Ebean.find(Order.class)
 			.setAutofetch(false)
 			.setUseCache(true)

--- a/src/test/java/org/avaje/ebeantest/LoggedSqlCollector.java
+++ b/src/test/java/org/avaje/ebeantest/LoggedSqlCollector.java
@@ -1,0 +1,87 @@
+package org.avaje.ebeantest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+
+/**
+ * Helper that can collect the SQL that is logged via SLF4J.
+ * <p>
+ * Used {@link #start()} and {@link #stop()} to collect the logged messages that contain the
+ * executed SQL statements.
+ * <p>
+ * Internally this uses a Logback Appender to collect messages for org.avaje.ebean.SQL.
+ */
+public class LoggedSqlCollector {
+
+  private static BasicAppender basicAppender = new BasicAppender();
+
+  static {
+
+    LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+    basicAppender.setContext(lc);
+
+    Logger logger = (Logger) LoggerFactory.getLogger("org.avaje.ebean.SQL");
+    logger.addAppender(basicAppender);
+    logger.setLevel(Level.TRACE);
+    logger.setAdditive(true);
+  }
+
+  /**
+   * Start collection of the logged SQL statements.
+   */
+  public static List<String> start() {
+    return basicAppender.collectStart();
+  }
+
+  /**
+   * Stop collection of the logged SQL statements return the list of captured messages that contain
+   * the SQL.
+   */
+  public static List<String> stop() {
+    return basicAppender.collectEnd();
+  }
+
+  private static class BasicAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+
+    List<String> messages = new ArrayList<String>();
+
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+      if (started) {
+        messages.add(eventObject.getMessage());
+      }
+    }
+
+    /**
+     * Start collection.
+     */
+    List<String> collectStart() {
+      List<String> tempMessages = messages;
+      messages = new ArrayList<String>();
+      // set started flag
+      start();
+      return tempMessages;
+    }
+
+    /**
+     * End collection.
+     */
+    List<String> collectEnd() {
+      // set stopped state
+      stop();
+      List<String> tempMessages = messages;
+      messages = new ArrayList<String>();
+      return tempMessages;
+    }
+
+  }
+}


### PR DESCRIPTION
This fix is mainly for 3.3 branch (does not exists) which is used in Play Framework 2.3.x

Conflicts:
	src/main/java/com/avaje/ebeaninternal/server/deploy/BeanPropertyAssocMany.java
	src/test/java/com/avaje/tests/query/orderby/TestOrderByWithMany.java