### PR TITLE
Update ScalarTypeEnumStandard.java

### DIFF
--- a/src/main/java/com/avaje/ebeaninternal/server/type/ScalarTypeEnumStandard.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/type/ScalarTypeEnumStandard.java
@@ -66,7 +66,7 @@ public class ScalarTypeEnumStandard {
       Object[] ea = enumType.getEnumConstants();
       for (int i = 0; i < ea.length; i++) {
         Enum<?> e = (Enum<?>) ea[i];
-        maxLen = Math.max(maxLen, e.toString().length());
+        maxLen = Math.max(maxLen, e.name().length());
       }
 
       return maxLen;


### PR DESCRIPTION
Using toString() to calculate the Enum length is wrong. If you overwrite the Enum's toString() the length may be shorter. In this situation, the ddl script will create a to small varchar field for the value and you get an exception on save "Data truncation: Data too long for column"

public enum Test {
        LONG_ENUM("short");
        private final String caption;
        private Test(String caption) {
            this.caption = caption;
        }
        @Override
        public String toString() {
            return caption;
        }
    }