### PR TITLE
generate table comment and column commnet in generate create ddl

### DIFF
--- a/src/main/java/com/avaje/ebean/annotation/DbComment.java
+++ b/src/main/java/com/avaje/ebean/annotation/DbComment.java
@@ -1,0 +1,16 @@
+package com.avaje.ebean.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * use to database's table or column comment
+ * Created by tomwen on 2015/11/19.
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DbComment {
+    String value();
+}

--- a/src/main/java/com/avaje/ebean/dbmigration/ddlgeneration/platform/MySqlDdl.java
+++ b/src/main/java/com/avaje/ebean/dbmigration/ddlgeneration/platform/MySqlDdl.java
@@ -2,7 +2,12 @@ package com.avaje.ebean.dbmigration.ddlgeneration.platform;
 
 import com.avaje.ebean.config.dbplatform.DbIdentity;
 import com.avaje.ebean.config.dbplatform.DbTypeMap;
+import com.avaje.ebean.dbmigration.ddlgeneration.DdlBuffer;
 import com.avaje.ebean.dbmigration.migration.AlterColumn;
+import com.avaje.ebean.dbmigration.migration.Column;
+import com.avaje.ebean.util.StringHelper;
+
+import java.io.IOException;
 
 /**
  * MySql specific DDL.
@@ -63,5 +68,19 @@ public class MySqlDdl extends PlatformDdl {
 
     // use modify
     return "alter table " + tableName + " modify " + columnName + " " + type + notnullClause;
+  }
+
+  @Override
+  protected void writeColumnDefinition(DdlBuffer buffer, Column column, boolean useIdentity) throws IOException {
+    super.writeColumnDefinition(buffer, column, useIdentity);
+    String comment = column.getComment();
+    if (!StringHelper.isNull(comment)) {
+      // in mysql 5.5 column comment save in information_schema.COLUMNS.COLUMN_COMMENT(VARCHAR 1024)
+      if (comment.length() > 500) {
+        comment = comment.substring(0,500);
+      }
+      buffer.append(String.format(" COMMENT '%s'", comment));
+    }
+
   }
 }

--- a/src/main/java/com/avaje/ebean/dbmigration/model/MColumn.java
+++ b/src/main/java/com/avaje/ebean/dbmigration/model/MColumn.java
@@ -25,6 +25,11 @@ public class MColumn {
   private String unique;
 
   /**
+   * column comment.
+   */
+  private String comment;
+
+  /**
    * Special unique for OneToOne as we need to handle that different
    * specifically for MsSqlServer.
    */
@@ -157,6 +162,14 @@ public class MColumn {
 
   public String getUnique() {
     return unique;
+  }
+
+  public String getComment() {
+    return comment;
+  }
+
+  public void setComment(String comment) {
+    this.comment = comment;
   }
 
   /**

--- a/src/main/java/com/avaje/ebean/dbmigration/model/MTable.java
+++ b/src/main/java/com/avaje/ebean/dbmigration/model/MTable.java
@@ -121,6 +121,7 @@ public class MTable {
     this.sequenceName = createTable.getSequenceName();
     this.sequenceInitial = toInt(createTable.getSequenceInitial());
     this.sequenceAllocate = toInt(createTable.getSequenceAllocate());
+    this.comment = createTable.getComment();
     List<Column> cols = createTable.getColumn();
     for (Column column : cols) {
       addColumn(column);
@@ -164,7 +165,9 @@ public class MTable {
     }
 
     for (MColumn column : this.columns.values()) {
-      createTable.getColumn().add(column.createColumn());
+      Column col = column.createColumn();
+      col.setComment(column.getComment());
+      createTable.getColumn().add(col);
     }
 
     for (MCompoundForeignKey compoundKey : compoundKeys) {
@@ -281,6 +284,10 @@ public class MTable {
 
   public String getComment() {
     return comment;
+  }
+
+  public void setComment(String comment) {
+    this.comment = comment;
   }
 
   public String getTablespace() {

--- a/src/main/java/com/avaje/ebean/dbmigration/model/build/ModelBuildBeanVisitor.java
+++ b/src/main/java/com/avaje/ebean/dbmigration/model/build/ModelBuildBeanVisitor.java
@@ -1,5 +1,6 @@
 package com.avaje.ebean.dbmigration.model.build;
 
+import com.avaje.ebean.annotation.DbComment;
 import com.avaje.ebean.config.dbplatform.DbType;
 import com.avaje.ebean.config.dbplatform.IdType;
 import com.avaje.ebean.dbmigration.migration.IdentityType;
@@ -36,6 +37,10 @@ public class ModelBuildBeanVisitor implements BeanVisitor {
     }
 
     MTable table = new MTable(descriptor.getBaseTable());
+    DbComment tableComment = descriptor.getBeanType().getAnnotation(DbComment.class);
+    if (tableComment != null) {
+      table.setComment(tableComment.value());
+    }
     if (descriptor.isHistorySupport()) {
       table.setWithHistory(true);
       BeanProperty whenCreated = descriptor.findWhenCreatedProperty();

--- a/src/main/java/com/avaje/ebean/dbmigration/model/build/ModelBuildIntersectionTable.java
+++ b/src/main/java/com/avaje/ebean/dbmigration/model/build/ModelBuildIntersectionTable.java
@@ -21,9 +21,9 @@ public class ModelBuildIntersectionTable {
 	private final TableJoin intersectionTableJoin;
 	private final TableJoin tableJoin;
 
-  private MTable intersectionTable;
+	private MTable intersectionTable;
 
-  private int countForeignKey;
+	private int countForeignKey;
 
 	public ModelBuildIntersectionTable(ModelBuildContext ctx, BeanPropertyAssocMany<?> manyProp) {
 		this.ctx = ctx;
@@ -32,16 +32,16 @@ public class ModelBuildIntersectionTable {
 		this.tableJoin = manyProp.getTableJoin();
 	}
 
-  public void build() {
+	public void build() {
 
-    intersectionTable = createTable();
-    MTable existingTable = ctx.addTable(intersectionTable);
-    if (existingTable != null) {
-      throw new IllegalStateException("Property " + manyProp.getFullBeanName() + " has duplicate ManyToMany intersection table " + intersectionTable.getName()
-          + ". Please use @JoinTable to define unique table to use");
-    }
+		intersectionTable = createTable();
+		MTable existingTable = ctx.addTable(intersectionTable);
+		if (existingTable != null) {
+			throw new IllegalStateException("Property " + manyProp.getFullBeanName() + " has duplicate ManyToMany intersection table " + intersectionTable.getName()
+					+ ". Please use @JoinTable to define unique table to use");
+		}
 
-    buildFkConstraints();
+		buildFkConstraints();
 	}
 
 	private void buildFkConstraints() {
@@ -52,36 +52,36 @@ public class ModelBuildIntersectionTable {
 		BeanDescriptor<?> targetDesc = manyProp.getTargetDescriptor();
 		buildFkConstraints(targetDesc, tableJoin.columns(), false);
 
-    intersectionTable.checkDuplicateForeignKeys();
+		intersectionTable.checkDuplicateForeignKeys();
 	}
 
 	
 	private void buildFkConstraints(BeanDescriptor<?> desc, TableJoinColumn[] columns, boolean direction) {
 
-    String tableName = intersectionTableJoin.getTable();
-    String baseTable = desc.getBaseTable();
+		String tableName = intersectionTableJoin.getTable();
+		String baseTable = desc.getBaseTable();
 
-    String fkName = ctx.foreignKeyConstraintName(tableName, baseTable, ++countForeignKey);
-    String fkIndex = ctx.foreignKeyIndexName(tableName, baseTable, countForeignKey);
+		String fkName = ctx.foreignKeyConstraintName(tableName, baseTable, ++countForeignKey);
+		String fkIndex = ctx.foreignKeyIndexName(tableName, baseTable, countForeignKey);
 
-    MCompoundForeignKey foreignKey = new MCompoundForeignKey(fkName, desc.getBaseTable(), fkIndex);
-    intersectionTable.addForeignKey(foreignKey);
+		MCompoundForeignKey foreignKey = new MCompoundForeignKey(fkName, desc.getBaseTable(), fkIndex);
+		intersectionTable.addForeignKey(foreignKey);
 
 		for (int i = 0; i < columns.length; i++) {
 			String localCol = direction ? columns[i].getForeignDbColumn() : columns[i].getLocalDbColumn();
-      String refCol = !direction ? columns[i].getForeignDbColumn() : columns[i].getLocalDbColumn();
-      foreignKey.addColumnPair(localCol, refCol);
+			String refCol = !direction ? columns[i].getForeignDbColumn() : columns[i].getLocalDbColumn();
+			foreignKey.addColumnPair(localCol, refCol);
 		}
-  }
+	}
 
 	private MTable createTable() {
 
 		BeanDescriptor<?> localDesc = manyProp.getBeanDescriptor();
 		BeanDescriptor<?> targetDesc = manyProp.getTargetDescriptor();
 
-    String tableName = intersectionTableJoin.getTable();
-    MTable table = new MTable(tableName);
-    table.setPkName(ctx.primaryKeyName(tableName));
+		String tableName = intersectionTableJoin.getTable();
+		MTable table = new MTable(tableName);
+		table.setPkName(ctx.primaryKeyName(tableName));
 
 		TableJoinColumn[] columns = intersectionTableJoin.columns();
 		for (int i = 0; i < columns.length; i++) {
@@ -93,7 +93,7 @@ public class ModelBuildIntersectionTable {
 			addColumn(table, targetDesc, otherColumns[i].getLocalDbColumn(), otherColumns[i].getForeignDbColumn());
 		}
 
-    return table;
+		return table;
 	}
 
 	private void addColumn(MTable table, BeanDescriptor<?> desc, String column, String findPropColumn) {
@@ -103,9 +103,10 @@ public class ModelBuildIntersectionTable {
 			throw new RuntimeException("Could not find id property for " + findPropColumn);
 		}
 
-    MColumn col = new MColumn(column, ctx.getColumnDefn(p), true);
-    col.setPrimaryKey(true);
-    table.addColumn(col);
+		MColumn col = new MColumn(column, ctx.getColumnDefn(p), true);
+		col.setPrimaryKey(true);
+		col.setComment(p.fetchDbColumn());
+		table.addColumn(col);
 	}
 
 }

--- a/src/main/java/com/avaje/ebean/dbmigration/model/build/ModelBuildPropertyVisitor.java
+++ b/src/main/java/com/avaje/ebean/dbmigration/model/build/ModelBuildPropertyVisitor.java
@@ -213,6 +213,7 @@ public class ModelBuildPropertyVisitor extends BaseTablePropertyVisitor {
     }
 
     MColumn col = new MColumn(p.getDbColumn(), ctx.getColumnDefn(p));
+    col.setComment(p.fetchDbColumn());
 
     if (p.isId()) {
       col.setPrimaryKey(true);

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/BeanProperty.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/BeanProperty.java
@@ -1,6 +1,7 @@
 package com.avaje.ebeaninternal.server.deploy;
 
 import com.avaje.ebean.ValuePair;
+import com.avaje.ebean.annotation.DbComment;
 import com.avaje.ebean.bean.EntityBean;
 import com.avaje.ebean.config.EncryptKey;
 import com.avaje.ebean.config.dbplatform.DbEncryptFunction;
@@ -1130,5 +1131,15 @@ public class BeanProperty implements ElPropertyValue {
       String propName = (prefix == null) ? name : prefix + "." + name;
       map.put(propName, new ValuePair(newVal, oldVal));
     }
+  }
+
+  public String fetchDbColumn() {
+    if (field != null) {
+      DbComment colComment = field.getAnnotation(DbComment.class);
+      if (colComment != null && !StringHelper.isNull(colComment.value())) {
+        return colComment.value();
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
this pull request used to solve the issue #356 . 
It generate table comment and column comment in the generate create ddl segment. 
If you have a model like 
```java
import com.avaje.ebean.Model;
import com.avaje.ebean.annotation.DbComment;
import lombok.Data;
import lombok.EqualsAndHashCode;

import javax.persistence.Entity;
import javax.persistence.Id;
import javax.persistence.Table;

@DbComment("购物车表")
@Entity
@Table(name = "t_cart")
@Data
@EqualsAndHashCode(callSuper = true)
public class Cart extends Model {

    @Id
    Long id;

    @DbComment("用户id")
    Long userId;

    @DbComment("跟踪id")
    String trackId;

    Long skuId;

    @DbComment("数量")
    Integer num;
}
```

then use 

```java
DefaultServer defaultServer = (DefaultServer)Ebean.getDefaultServer();
String s = defaultServer.getDdlGenerator().generateCreateDdl();
```

If the db is mysql, the String s will be 

```sql
create table t_cart (
  id                            bigint auto_increment not null,
  order_no                      varchar(255) COMMENT '订单号',
  user_id                       bigint COMMENT '用户id',
  track_id                      varchar(255) COMMENT '跟踪id',
  seller_id                     bigint COMMENT '所属卖家',
  order_status                  integer COMMENT '订单状态',
  total_price                   bigint COMMENT '订单金额',
  pay_method                    integer COMMENT '付款方式. 支付宝(Alipay), 微信(Wechat) 等',
  constraint ck_t_cart_order_status check (order_status in (0,1,2,3,4,5,6)),
  constraint ck_t_cart_pay_method check (pay_method in (0,1)),
  constraint pk_t_cart primary key (id)
) COMMENT='购物车表';
```

If model  like

```java
import com.avaje.ebean.annotation.DbComment;
import org.example.domain.finder.CustomerFinder;

import java.util.ArrayList;
import java.util.Date;
import java.util.List;

import javax.persistence.CascadeType;
import javax.persistence.Column;
import javax.persistence.Entity;
import javax.persistence.ManyToOne;
import javax.persistence.OneToMany;
import javax.persistence.Table;

/**
 * Customer entity bean.
 */
@Entity
@Table(name="be_customer")
@DbComment("客户表")
public class Customer extends BaseModel {

  /**
   * Convenience Finder for 'active record' style.
   */
  public static final CustomerFinder find = new CustomerFinder();
  
  boolean inactive;
  
  @Column(length=100)
  @DbComment("姓名")
  String name;

  Date registered;
  
  @Column(length=1000)
  @DbComment("注释")
  String comments;
  
  @ManyToOne(cascade=CascadeType.ALL)
  Address billingAddress;

  @ManyToOne(cascade=CascadeType.ALL)
  Address shippingAddress;

  @OneToMany(mappedBy="customer", cascade=CascadeType.PERSIST)
  List<Contact> contacts;

  @OneToMany(mappedBy="customer")
  List<Order> orders;
```

and  the db is db2, sqlserver, oracle, Postgres, Hsql, h2. the String s will be 

```sql
create table be_customer (
  id                            bigint not null,
  inactive                      boolean,
  name                          varchar(100),
  registered                    timestamp,
  comments                      varchar(1000),
  billing_address_id            bigint,
  shipping_address_id           bigint,
  version                       bigint not null,
  when_created                  timestamp not null,
  when_updated                  timestamp not null,
  constraint pk_be_customer primary key (id)
);
COMMENT ON TABLE be_customer IS '客户表';
COMMENT ON COLUMN be_customer.name IS '姓名';
COMMENT ON COLUMN be_customer.comments IS '注释';
```

please take a moment to see the pull request, will it ok? thanks!
