### PR TITLE
SQLite Ddl : autoincrement attribute

### DIFF
--- a/src/main/java/com/avaje/ebean/dbmigration/ddlgeneration/platform/SQLiteDdl.java
+++ b/src/main/java/com/avaje/ebean/dbmigration/ddlgeneration/platform/SQLiteDdl.java
@@ -10,7 +10,7 @@ public class SQLiteDdl extends PlatformDdl {
 
   public SQLiteDdl(DbTypeMap platformTypes, DbIdentity dbIdentity) {
     super(platformTypes, dbIdentity);
-    this.identitySuffix = " autoincrement";
+    this.identitySuffix = "";
   }
   
 }


### PR DESCRIPTION
https://www.sqlite.org/autoinc.html

Apparently SQLite syntax doesn't accept the keyword `autoincrement` alone in the datatype.