### PR TITLE
Fixing squid:S1210 - "equals(Object obj)" should be overridden along with the "compareTo(T obj)" method

### DIFF
--- a/src/main/java/com/avaje/ebean/dbmigration/model/MigrationResource.java
+++ b/src/main/java/com/avaje/ebean/dbmigration/model/MigrationResource.java
@@ -48,4 +48,30 @@ public class MigrationResource implements Comparable<MigrationResource> {
   public int compareTo(MigrationResource other) {
     return version.compareTo(other.version);
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) {
+      return false;
+    }
+    if (obj == this) {
+      return true;
+    }
+    if (obj.getClass() == this.getClass()) {
+      MigrationResource other = (MigrationResource) obj;
+      boolean result = true;
+      result &= version != null ? version.equals(other.version) : other.version == null;
+      result &= migrationFile != null ? migrationFile.equals(other.migrationFile) : other.migrationFile == null;
+      return result;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 23;
+    result = version != null ? 31 * result + version.hashCode() : result;
+    result = migrationFile != null ? 31 * result + migrationFile.hashCode() : result;
+    return result;
+  }
 }

--- a/src/main/java/com/avaje/ebean/dbmigration/model/MigrationVersion.java
+++ b/src/main/java/com/avaje/ebean/dbmigration/model/MigrationVersion.java
@@ -141,6 +141,32 @@ public class MigrationVersion implements Comparable<MigrationVersion> {
     return comment.compareTo(other.comment);
   }
 
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) {
+      return false;
+    }
+    if (obj == this) {
+      return true;
+    }
+    if (obj.getClass() == this.getClass()) {
+      MigrationVersion other = (MigrationVersion) obj;
+      boolean result = true;
+      result &= raw != null ? raw.equals(other.raw) : other.raw == null;
+      result &= comment != null ? comment.equals(other.comment) : other.comment == null;
+      return result;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 25;
+    result = raw != null ? 31 * result + raw.hashCode() : result;
+    result = comment != null ? 31 * result + comment.hashCode() : result;
+    return result;
+  }
+
   /**
    * Parse the raw version string and just return the leading version number;
    */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1210 - “"equals(Object obj)" should be overridden along with the "compareTo(T obj)" method”. 
You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1210
Please let me know if you have any questions.
Artyom Melnikov.