### PR TITLE
Fixing squid:S1444 - "public static" fields should be constant

### DIFF
--- a/src/main/java/com/avaje/ebeaninternal/server/core/CacheOptions.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/core/CacheOptions.java
@@ -10,7 +10,7 @@ public class CacheOptions {
   /**
    * Instance when no caching is used.
    */
-  public static CacheOptions NO_CACHING = new CacheOptions();
+  public static final CacheOptions NO_CACHING = new CacheOptions();
 
   private final boolean enableBeanCache;
   private final boolean enableQueryCache;

--- a/src/main/java/com/avaje/ebeaninternal/server/idgen/UuidIdGenerator.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/idgen/UuidIdGenerator.java
@@ -10,7 +10,7 @@ import java.util.UUID;
  */
 public class UuidIdGenerator implements PlatformIdGenerator {
 
-  public static UuidIdGenerator INSTANCE = new UuidIdGenerator();
+  public static final UuidIdGenerator INSTANCE = new UuidIdGenerator();
 
   /**
    * Return UUID from UUID.randomUUID();

--- a/src/test/java/com/avaje/tests/model/basic/MyEBasicConfigStartup.java
+++ b/src/test/java/com/avaje/tests/model/basic/MyEBasicConfigStartup.java
@@ -12,9 +12,9 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class MyEBasicConfigStartup implements ServerConfigStartup {
 
-  public static AtomicLong insertCount = new AtomicLong();
-  public static AtomicLong updateCount = new AtomicLong();
-  public static AtomicLong deleteCount = new AtomicLong();
+  public static final AtomicLong insertCount = new AtomicLong();
+  public static final AtomicLong updateCount = new AtomicLong();
+  public static final AtomicLong deleteCount = new AtomicLong();
 
   public static void resetCounters() {
     insertCount.set(0);

--- a/src/test/java/com/avaje/tests/model/info/InfoCompany.java
+++ b/src/test/java/com/avaje/tests/model/info/InfoCompany.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Entity
 public class InfoCompany extends Model {
 
-  public static Finder<Long,InfoCompany> find = new Finder<Long,InfoCompany>(InfoCompany.class);
+  public static final Finder<Long,InfoCompany> find = new Finder<Long,InfoCompany>(InfoCompany.class);
 
   @Id
   Long id;

--- a/src/test/java/com/avaje/tests/model/info/InfoCustomer.java
+++ b/src/test/java/com/avaje/tests/model/info/InfoCustomer.java
@@ -11,7 +11,7 @@ import javax.persistence.Version;
 @Entity
 public class InfoCustomer extends Model {
 
-  public static Finder<Long,InfoCustomer> find = new Finder<Long,InfoCustomer>(InfoCustomer.class);
+  public static final Finder<Long,InfoCustomer> find = new Finder<Long,InfoCustomer>(InfoCustomer.class);
 
   @Id
   Long id;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1444 - “"public static" fields should be constant”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1444
 Please let me know if you have any questions.
Artyom Melnikov.