### PR TITLE
Fixing squid:S1148 - Throwable.printStackTrace(...) should not be called

### DIFF
--- a/src/main/java/com/avaje/ebeaninternal/server/lib/DaemonScheduleThreadPool.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/lib/DaemonScheduleThreadPool.java
@@ -62,7 +62,6 @@ public final class DaemonScheduleThreadPool extends ScheduledThreadPoolExecutor 
 
       } catch (Exception e) {
         logger.error("Error during shutdown of " + namePrefix, e);
-        e.printStackTrace();
       }
     }
   }

--- a/src/main/java/com/avaje/ebeaninternal/server/lib/DaemonThreadPool.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/lib/DaemonThreadPool.java
@@ -69,7 +69,6 @@ public final class DaemonThreadPool extends ThreadPoolExecutor {
 
       } catch (Exception e) {
         logger.error("Error during shutdown of DaemonThreadPool[" + namePrefix + "]", e);
-        e.printStackTrace();
       }
     }
   }

--- a/src/main/java/com/avaje/ebeaninternal/server/lib/ShutdownManager.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/lib/ShutdownManager.java
@@ -147,7 +147,6 @@ public final class ShutdownManager {
           server.shutdownManaged();
         } catch (Exception ex) {
           logger.error("Error executing shutdown runnable", ex);
-          ex.printStackTrace();
         }
       }
       


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1148 - “Throwable.printStackTrace(...) should not be called”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1148
 Please let me know if you have any questions.
 Artyom Melnikov.