### PR TITLE
Fixing squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/main/java/com/avaje/ebean/config/dbplatform/SequenceIdGenerator.java
+++ b/src/main/java/com/avaje/ebean/config/dbplatform/SequenceIdGenerator.java
@@ -114,7 +114,7 @@ public abstract class SequenceIdGenerator implements PlatformIdGenerator {
   public Object nextId(Transaction t) {
     synchronized (monitor) {
 
-      if (idList.size() == 0) {
+      if (idList.isEmpty()) {
         loadMoreIds(batchSize, t);
       }
       Long nextId = idList.remove(0);
@@ -193,7 +193,7 @@ public abstract class SequenceIdGenerator implements PlatformIdGenerator {
       while (rset.next()) {
         newIds.add(rset.getLong(1));
       }
-      if (newIds.size() == 0) {
+      if (newIds.isEmpty()) {
         throw new PersistenceException("Always expecting more than 1 row from " + sql);
       }
 

--- a/src/main/java/com/avaje/ebeaninternal/server/core/DefaultContainer.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/core/DefaultContainer.java
@@ -218,7 +218,7 @@ public class DefaultContainer implements SpiContainer {
   private BootupClasses getBootupClasses1(ServerConfig serverConfig) {
 
     List<Class<?>> entityClasses = serverConfig.getClasses();
-    if (serverConfig.isDisableClasspathSearch() || (entityClasses != null && entityClasses.size() > 0)) {
+    if (serverConfig.isDisableClasspathSearch() || (entityClasses != null && !entityClasses.isEmpty())) {
       // use classes we explicitly added via configuration
       return new BootupClasses(entityClasses);
     }

--- a/src/main/java/com/avaje/ebeaninternal/server/core/DefaultServer.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/core/DefaultServer.java
@@ -836,7 +836,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     if (sortByClause == null) {
       throw new NullPointerException("sortByClause is null");
     }
-    if (list.size() == 0) {
+    if (list.isEmpty()) {
       // don't need to sort an empty list
       return;
     }

--- a/src/main/java/com/avaje/ebeaninternal/server/core/bootup/BootupClassPathSearch.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/core/bootup/BootupClassPathSearch.java
@@ -49,7 +49,7 @@ public class BootupClassPathSearch {
 
       long st = System.currentTimeMillis();
       for (ClassPathScanner finder : this.scanners) {
-        if (packages != null && packages.size() > 0) {
+        if (packages != null && !packages.isEmpty()) {
           for (String packageName : packages) {
             finder.scanForClasses(packageName, bc);
           }

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -794,7 +794,7 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
       }
     }
 
-    if (matchSet.size() == 0) {
+    if (matchSet.isEmpty()) {
       // this is a unidirectional relationship
       // ... that is no matching property on the 'detail' bean
       return false;

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
@@ -477,7 +477,7 @@ public class DeployBeanDescriptor<T> {
    * Return the BeanPersistController (could be a chain of them, 1 or null).
    */
   public BeanPersistController getPersistController() {
-    if (persistControllers.size() == 0) {
+    if (persistControllers.isEmpty()) {
       return null;
     } else if (persistControllers.size() == 1) {
       return persistControllers.get(0);
@@ -490,7 +490,7 @@ public class DeployBeanDescriptor<T> {
    * Return the BeanPersistListener (could be a chain of them, 1 or null).
    */
   public BeanPersistListener getPersistListener() {
-    if (persistListeners.size() == 0) {
+    if (persistListeners.isEmpty()) {
       return null;
     } else if (persistListeners.size() == 1) {
       return persistListeners.get(0);
@@ -500,7 +500,7 @@ public class DeployBeanDescriptor<T> {
   }
 
   public BeanQueryAdapter getQueryAdapter() {
-    if (queryAdapters.size() == 0) {
+    if (queryAdapters.isEmpty()) {
       return null;
     } else if (queryAdapters.size() == 1) {
       return queryAdapters.get(0);
@@ -513,7 +513,7 @@ public class DeployBeanDescriptor<T> {
    * Return the BeanPostLoad (could be a chain of them, 1 or null).
    */
   public BeanPostLoad getPostLoad() {
-    if (postLoaders.size() == 0) {
+    if (postLoaders.isEmpty()) {
       return null;
     } else if (postLoaders.size() == 1) {
       return postLoaders.get(0);

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployTableJoin.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployTableJoin.java
@@ -46,7 +46,7 @@ public class DeployTableJoin {
    * Return true if the JoinOnPair have been set.
    */
   public boolean hasJoinColumns() {
-    return columns.size() > 0;
+    return !columns.isEmpty();
   }
 
   /**

--- a/src/main/java/com/avaje/ebeaninternal/server/persist/DefaultPersister.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/persist/DefaultPersister.java
@@ -567,7 +567,7 @@ public final class DefaultPersister implements Persister {
    */
   public int deleteMany(Class<?> beanType, Collection<?> ids, Transaction transaction, boolean permanent) {
 
-    if (ids == null || ids.size() == 0) {
+    if (ids == null || ids.isEmpty()) {
       return 0;
     }
 

--- a/src/main/java/com/avaje/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -522,7 +522,7 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
       List<SpiExpression> exprList = whereExpressions.internalList();
       if (exprList.size() > 1) {
         return null;
-      } else if (exprList.size() == 0) {
+      } else if (exprList.isEmpty()) {
         return namedBind;
       } else {
         if (namedBind != null) {

--- a/src/main/java/com/avaje/ebeaninternal/server/querydefn/OrmQueryDetail.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/querydefn/OrmQueryDetail.java
@@ -198,7 +198,7 @@ public class OrmQueryDetail implements Serializable {
       }
     }
 
-    if (matchingPaths.size() == 0) {
+    if (matchingPaths.isEmpty()) {
       return null;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1155
 Please let me know if you have any questions.
 Artyom Melnikov.