### PR TITLE
Fixing squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/main/java/com/avaje/ebean/DRawSqlColumnsParser.java
+++ b/src/main/java/com/avaje/ebean/DRawSqlColumnsParser.java
@@ -49,7 +49,7 @@ final class DRawSqlColumnsParser {
     if (split.length > 1) {
       ArrayList<String> tmp = new ArrayList<String>(split.length);
       for (int i = 0; i < split.length; i++) {
-        if (split[i].trim().length() > 0) {
+        if (!split[i].trim().isEmpty()) {
           tmp.add(split[i].trim());
         }
       }

--- a/src/main/java/com/avaje/ebean/Ebean.java
+++ b/src/main/java/com/avaje/ebean/Ebean.java
@@ -161,7 +161,7 @@ public final class Ebean {
           // look to see if there is a default server defined
           String defaultName = PrimaryServer.getDefaultServerName();
           logger.debug("defaultName:" + defaultName);
-          if (defaultName != null && defaultName.trim().length() > 0) {
+          if (defaultName != null && !defaultName.trim().isEmpty()) {
             defaultServer = getWithCreate(defaultName.trim());
           }
         }
@@ -182,7 +182,7 @@ public final class Ebean {
     }
 
     private EbeanServer get(String name) {
-      if (name == null || name.length() == 0) {
+      if (name == null || name.isEmpty()) {
         return defaultServer;
       }
       // non-synchronized read

--- a/src/main/java/com/avaje/ebean/OrderBy.java
+++ b/src/main/java/com/avaje/ebean/OrderBy.java
@@ -400,6 +400,6 @@ public final class OrderBy<T> implements Serializable {
   }
 
   private boolean isEmptyString(String s) {
-    return s == null || s.length() == 0;
+    return s == null || s.isEmpty();
   }
 }

--- a/src/main/java/com/avaje/ebean/PrimaryServer.java
+++ b/src/main/java/com/avaje/ebean/PrimaryServer.java
@@ -78,6 +78,6 @@ class PrimaryServer {
    * Return true if the string is null or empty.
    */
   private static boolean isEmpty(String value) {
-    return value == null || value.trim().length() == 0;
+    return value == null || value.trim().isEmpty();
   }
 }

--- a/src/main/java/com/avaje/ebean/config/AbstractNamingConvention.java
+++ b/src/main/java/com/avaje/ebean/config/AbstractNamingConvention.java
@@ -274,7 +274,7 @@ public abstract class AbstractNamingConvention implements NamingConvention {
    * Checks string is null or empty .
    */
   protected boolean isEmpty(String s) {
-    return s == null || s.trim().length() == 0;
+    return s == null || s.trim().isEmpty();
   }
 
   /**

--- a/src/main/java/com/avaje/ebean/config/ServerConfig.java
+++ b/src/main/java/com/avaje/ebean/config/ServerConfig.java
@@ -2460,7 +2460,7 @@ public class ServerConfig {
     String[] split = classNames.split("[ ,;]");
     for (int i = 0; i < split.length; i++) {
       String cn = split[i].trim();
-      if (cn.length() > 0 && !"class".equalsIgnoreCase(cn)) {
+      if (!cn.isEmpty() && !"class".equalsIgnoreCase(cn)) {
         try {
           classes.add(Class.forName(cn));
         } catch (ClassNotFoundException e) {

--- a/src/main/java/com/avaje/ebean/config/TableName.java
+++ b/src/main/java/com/avaje/ebean/config/TableName.java
@@ -146,6 +146,6 @@ public final class TableName {
    * @return true, if is valid
    */
   public boolean isValid() {
-    return name != null && name.length() > 0;
+    return name != null && !name.isEmpty();
   }
 }

--- a/src/main/java/com/avaje/ebean/config/dbplatform/DatabasePlatform.java
+++ b/src/main/java/com/avaje/ebean/config/dbplatform/DatabasePlatform.java
@@ -492,7 +492,7 @@ public class DatabasePlatform {
    */
   public String convertQuotedIdentifiers(String dbName) {
     // Ignore null values e.g. schema name or catalog
-    if (dbName != null && dbName.length() > 0) {
+    if (dbName != null && !dbName.isEmpty()) {
       if (dbName.charAt(0) == BACK_TICK) {
         if (dbName.charAt(dbName.length() - 1) == BACK_TICK) {
 

--- a/src/main/java/com/avaje/ebean/config/dbplatform/SequenceIdGenerator.java
+++ b/src/main/java/com/avaje/ebean/config/dbplatform/SequenceIdGenerator.java
@@ -114,7 +114,7 @@ public abstract class SequenceIdGenerator implements PlatformIdGenerator {
   public Object nextId(Transaction t) {
     synchronized (monitor) {
 
-      if (idList.size() == 0) {
+      if (idList.isEmpty()) {
         loadMoreIds(batchSize, t);
       }
       Long nextId = idList.remove(0);
@@ -193,7 +193,7 @@ public abstract class SequenceIdGenerator implements PlatformIdGenerator {
       while (rset.next()) {
         newIds.add(rset.getLong(1));
       }
-      if (newIds.size() == 0) {
+      if (newIds.isEmpty()) {
         throw new PersistenceException("Always expecting more than 1 row from " + sql);
       }
 

--- a/src/main/java/com/avaje/ebean/text/PathProperties.java
+++ b/src/main/java/com/avaje/ebean/text/PathProperties.java
@@ -109,7 +109,7 @@ public class PathProperties implements FetchPath {
       String path = entry.getKey();
       String props = entry.getValue().getPropertiesAsString();
 
-      if (path == null || path.length() == 0) {
+      if (path == null || path.isEmpty()) {
         query.select(props);
       } else {
         query.fetch(path, props);

--- a/src/main/java/com/avaje/ebean/text/PathPropertiesParser.java
+++ b/src/main/java/com/avaje/ebean/text/PathPropertiesParser.java
@@ -108,7 +108,7 @@ class PathPropertiesParser {
 
   private void addCurrentProperty() {
     String w = currentWord();
-    if (w.length() > 0) {
+    if (!w.isEmpty()) {
       currentPathProps.addProperty(w);
     }
   }

--- a/src/main/java/com/avaje/ebean/text/TimeStringParser.java
+++ b/src/main/java/com/avaje/ebean/text/TimeStringParser.java
@@ -23,7 +23,7 @@ public final class TimeStringParser implements StringParser {
    */
   @SuppressWarnings("deprecation")
   public Object parse(String value) {
-    if (value == null || value.trim().length() == 0) {
+    if (value == null || value.trim().isEmpty()) {
       return null;
     }
 

--- a/src/main/java/com/avaje/ebean/util/StringHelper.java
+++ b/src/main/java/com/avaje/ebean/util/StringHelper.java
@@ -123,7 +123,7 @@ public class StringHelper {
       String listDelimiter, String nameValueSeparator) {
 
     HashMap<String, String> params = new HashMap<String, String>();
-    if ((allNameValuePairs == null) || (allNameValuePairs.length() == 0)) {
+    if ((allNameValuePairs == null) || (allNameValuePairs.isEmpty())) {
       return params;
     }
     // trim off any leading listDelimiter...
@@ -155,7 +155,7 @@ public class StringHelper {
    * Return true if the value is null or an empty string.
    */
   public static boolean isNull(String value) {
-    return value == null || value.trim().length() == 0;
+    return value == null || value.trim().isEmpty();
   }
 
   /**
@@ -189,7 +189,7 @@ public class StringHelper {
       // there is a key without a value?
       String key = allNameValuePairs.substring(pos, delimPos);
       key = key.trim();
-      if (key.length() > 0) {
+      if (!key.isEmpty()) {
         map.put(key, null);
       }
       return getKeyValue(map, delimPos + 1, allNameValuePairs, listDelimiter,
@@ -251,7 +251,7 @@ public class StringHelper {
     if (endPos == -1) {
       if (startPos <= str.length()) {
         String lastValue = str.substring(startPos, str.length());
-        if (keepEmpties || lastValue.length() != 0) {
+        if (keepEmpties || !lastValue.isEmpty()) {
           list.add(lastValue);
         }
       }
@@ -260,7 +260,7 @@ public class StringHelper {
     } else {
       // get the delimited value... add it..
       String value = str.substring(startPos, endPos);
-      if (keepEmpties || value.length() != 0) {
+      if (keepEmpties || !value.isEmpty()) {
         list.add(value);
       }
       // recursively search as we are not at the end yet...

--- a/src/main/java/com/avaje/ebeaninternal/extraddl/model/ExtraDdlXmlReader.java
+++ b/src/main/java/com/avaje/ebeaninternal/extraddl/model/ExtraDdlXmlReader.java
@@ -40,7 +40,7 @@ public class ExtraDdlXmlReader {
    * @param platforms The platforms (comma delimited) this script should run for
    */
   public static boolean matchPlatform(String platformName, String platforms) {
-    if (platforms == null || platforms.trim().length() == 0) {
+    if (platforms == null || platforms.trim().isEmpty()) {
       return true;
     }
     String[] names = platforms.split("[,;]");

--- a/src/main/java/com/avaje/ebeaninternal/server/core/DefaultContainer.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/core/DefaultContainer.java
@@ -218,7 +218,7 @@ public class DefaultContainer implements SpiContainer {
   private BootupClasses getBootupClasses1(ServerConfig serverConfig) {
 
     List<Class<?>> entityClasses = serverConfig.getClasses();
-    if (serverConfig.isDisableClasspathSearch() || (entityClasses != null && entityClasses.size() > 0)) {
+    if (serverConfig.isDisableClasspathSearch() || (entityClasses != null && !entityClasses.isEmpty())) {
       // use classes we explicitly added via configuration
       return new BootupClasses(entityClasses);
     }

--- a/src/main/java/com/avaje/ebeaninternal/server/core/DefaultServer.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/core/DefaultServer.java
@@ -836,7 +836,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     if (sortByClause == null) {
       throw new NullPointerException("sortByClause is null");
     }
-    if (list.size() == 0) {
+    if (list.isEmpty()) {
       // don't need to sort an empty list
       return;
     }

--- a/src/main/java/com/avaje/ebeaninternal/server/core/bootup/BootupClassPathSearch.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/core/bootup/BootupClassPathSearch.java
@@ -49,7 +49,7 @@ public class BootupClassPathSearch {
 
       long st = System.currentTimeMillis();
       for (ClassPathScanner finder : this.scanners) {
-        if (packages != null && packages.size() > 0) {
+        if (packages != null && !packages.isEmpty()) {
           for (String packageName : packages) {
             finder.scanForClasses(packageName, bc);
           }

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -794,7 +794,7 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
       }
     }
 
-    if (matchSet.size() == 0) {
+    if (matchSet.isEmpty()) {
       // this is a unidirectional relationship
       // ... that is no matching property on the 'detail' bean
       return false;
@@ -1141,7 +1141,7 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
       // already assigned (So custom or UUID)
       return;
     }
-    if (desc.propertiesId().size() == 0) {
+    if (desc.propertiesId().isEmpty()) {
       // bean doesn't have an Id property
       if (desc.isBaseTableType() && desc.getBeanFinder() == null) {
         // expecting an id property

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
@@ -283,7 +283,7 @@ public class DeployBeanDescriptor<T> {
     docStoreUpdate = docStore.update();
     docStoreDelete = docStore.delete();
     String doc = docStore.doc();
-    if (doc.length() > 0) {
+    if (!doc.isEmpty()) {
       docStorePathProperties = PathProperties.parse(doc);
     }
   }
@@ -388,7 +388,7 @@ public class DeployBeanDescriptor<T> {
   public void setCache(Cache cache) {
 
     String naturalKey = null;
-    if (cache.naturalKey().length() > 0) {
+    if (!cache.naturalKey().isEmpty()) {
       // find the property and mark as natural key property
       String propName = cache.naturalKey().trim();
       DeployBeanProperty beanProperty = getBeanProperty(propName);
@@ -477,7 +477,7 @@ public class DeployBeanDescriptor<T> {
    * Return the BeanPersistController (could be a chain of them, 1 or null).
    */
   public BeanPersistController getPersistController() {
-    if (persistControllers.size() == 0) {
+    if (persistControllers.isEmpty()) {
       return null;
     } else if (persistControllers.size() == 1) {
       return persistControllers.get(0);
@@ -490,7 +490,7 @@ public class DeployBeanDescriptor<T> {
    * Return the BeanPersistListener (could be a chain of them, 1 or null).
    */
   public BeanPersistListener getPersistListener() {
-    if (persistListeners.size() == 0) {
+    if (persistListeners.isEmpty()) {
       return null;
     } else if (persistListeners.size() == 1) {
       return persistListeners.get(0);
@@ -500,7 +500,7 @@ public class DeployBeanDescriptor<T> {
   }
 
   public BeanQueryAdapter getQueryAdapter() {
-    if (queryAdapters.size() == 0) {
+    if (queryAdapters.isEmpty()) {
       return null;
     } else if (queryAdapters.size() == 1) {
       return queryAdapters.get(0);
@@ -513,7 +513,7 @@ public class DeployBeanDescriptor<T> {
    * Return the BeanPostLoad (could be a chain of them, 1 or null).
    */
   public BeanPostLoad getPostLoad() {
-    if (postLoaders.size() == 0) {
+    if (postLoaders.isEmpty()) {
       return null;
     } else if (postLoaders.size() == 1) {
       return postLoaders.get(0);
@@ -835,7 +835,7 @@ public class DeployBeanDescriptor<T> {
       return null;
     }
     String selectClause = sb.toString();
-    if (selectClause.length() == 0) {
+    if (selectClause.isEmpty()) {
       throw new IllegalStateException("Bean " + getFullName() + " has no properties?");
     }
     return selectClause.substring(0, selectClause.length() - 1);

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
@@ -386,7 +386,7 @@ public class DeployBeanProperty {
    * Set a specific DB column definition.
    */
   public void setDbColumnDefn(String dbColumnDefn) {
-    if (dbColumnDefn == null || dbColumnDefn.trim().length() == 0) {
+    if (dbColumnDefn == null || dbColumnDefn.trim().isEmpty()) {
       this.dbColumnDefn = null;
     } else {
       this.dbColumnDefn = InternString.intern(dbColumnDefn);

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployBeanPropertyAssocMany.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployBeanPropertyAssocMany.java
@@ -178,7 +178,7 @@ public class DeployBeanPropertyAssocMany<T> extends DeployBeanPropertyAssoc<T> {
 	 * Set the default mapKey to use when returning a Map.
 	 */
 	public void setMapKey(String mapKey) {
-		if (mapKey != null && mapKey.length() > 0) {
+		if (mapKey != null && !mapKey.isEmpty()) {
 			this.mapKey = mapKey;
 		}
 	}
@@ -188,7 +188,7 @@ public class DeployBeanPropertyAssocMany<T> extends DeployBeanPropertyAssoc<T> {
 	 * list, set or map.
 	 */
 	public void setFetchOrderBy(String orderBy) {
-		if (orderBy != null && orderBy.length() > 0) {
+		if (orderBy != null && !orderBy.isEmpty()) {
 			fetchOrderBy = orderBy;
 		}
 	}

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployTableJoin.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployTableJoin.java
@@ -46,7 +46,7 @@ public class DeployTableJoin {
    * Return true if the JoinOnPair have been set.
    */
   public boolean hasJoinColumns() {
-    return columns.size() > 0;
+    return !columns.isEmpty();
   }
 
   /**

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/parse/AnnotationBase.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/parse/AnnotationBase.java
@@ -32,7 +32,7 @@ public abstract class AnnotationBase {
    * Checks string is null or empty .
    */
   protected boolean isEmpty(String s) {
-    return s == null || s.trim().length() == 0;
+    return s == null || s.trim().isEmpty();
   }
 
 

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/parse/DeployInheritInfo.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/parse/DeployInheritInfo.java
@@ -188,7 +188,7 @@ public class DeployInheritInfo {
   public void setDiscriminatorValue(String value) {
     if (value != null) {
       value = value.trim();
-      if (value.length() != 0) {
+      if (!value.isEmpty()) {
         discriminatorStringValue = value;
         // convert the value if desired
         if (discriminatorType == Types.INTEGER) {

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/parse/SqlReservedWords.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/parse/SqlReservedWords.java
@@ -70,7 +70,7 @@ public class SqlReservedWords {
 	public static synchronized void addKeyword(String keyword){
 		if (keyword != null){
 			keyword = keyword.trim().toUpperCase();
-			if (keyword.length() > 0){
+			if (!keyword.isEmpty()){
 				keywords.add(keyword);				
 			}
 		}

--- a/src/main/java/com/avaje/ebeaninternal/server/lib/util/StringHelper.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/lib/util/StringHelper.java
@@ -24,7 +24,7 @@ public class StringHelper {
 			String listDelimiter, String nameValueSeparator) {
 
 		HashMap<String, String> params = new HashMap<String, String>();
-		if ((allNameValuePairs == null) || (allNameValuePairs.length() == 0)) {
+		if ((allNameValuePairs == null) || (allNameValuePairs.isEmpty())) {
 			return params;
 		}
 		// trim off any leading listDelimiter...
@@ -56,7 +56,7 @@ public class StringHelper {
 	 * Return true if the value is null or an empty string.
 	 */
 	public static boolean isNull(String value) {
-    return value == null || value.trim().length() == 0;
+    return value == null || value.trim().isEmpty();
   }
 
 	/**
@@ -90,7 +90,7 @@ public class StringHelper {
 			// there is a key without a value?
 			String key = allNameValuePairs.substring(pos, delimPos);
 			key = key.trim();
-			if (key.length() > 0) {
+			if (!key.isEmpty()) {
 				map.put(key, null);
 			}
 			return getKeyValue(map, delimPos + 1, allNameValuePairs, listDelimiter,

--- a/src/main/java/com/avaje/ebeaninternal/server/persist/DefaultPersister.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/persist/DefaultPersister.java
@@ -567,7 +567,7 @@ public final class DefaultPersister implements Persister {
    */
   public int deleteMany(Class<?> beanType, Collection<?> ids, Transaction transaction, boolean permanent) {
 
-    if (ids == null || ids.size() == 0) {
+    if (ids == null || ids.isEmpty()) {
       return 0;
     }
 

--- a/src/main/java/com/avaje/ebeaninternal/server/query/CQueryBuilder.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/query/CQueryBuilder.java
@@ -452,7 +452,7 @@ public class CQueryBuilder {
     String inheritanceWhere = select.getInheritanceWhereSql();
 
     boolean hasWhere = false;
-    if (inheritanceWhere.length() > 0) {
+    if (!inheritanceWhere.isEmpty()) {
       sb.append(" where");
       sb.append(inheritanceWhere);
       hasWhere = true;
@@ -557,7 +557,7 @@ public class CQueryBuilder {
   }
 
   private boolean isEmpty(String s) {
-    return s == null || s.length() == 0;
+    return s == null || s.isEmpty();
   }
 
 }

--- a/src/main/java/com/avaje/ebeaninternal/server/query/CQueryBuilderRawSql.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/query/CQueryBuilderRawSql.java
@@ -134,7 +134,7 @@ public class CQueryBuilderRawSql {
   }
 
   private boolean isEmpty(String s) {
-    return s == null || s.length() == 0;
+    return s == null || s.isEmpty();
   }
 
   private String getOrderBy(CQueryPredicates predicates, RawSql.Sql sql) {

--- a/src/main/java/com/avaje/ebeaninternal/server/query/CQueryPredicates.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/query/CQueryPredicates.java
@@ -305,7 +305,7 @@ public class CQueryPredicates {
   }
 
   private boolean isEmpty(String s) {
-    return s == null || s.length() == 0;
+    return s == null || s.isEmpty();
   }
 
   private String parse(String expr, DeployParser deployParser) {

--- a/src/main/java/com/avaje/ebeaninternal/server/query/DefaultDbSqlContext.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/query/DefaultDbSqlContext.java
@@ -138,7 +138,7 @@ public class DefaultDbSqlContext implements DbSqlContext {
 
 
     // add on any inheritance where clause
-    if (inheritance != null && inheritance.length() > 0) {
+    if (inheritance != null && !inheritance.isEmpty()) {
       sb.append(" and ");
       sb.append(a2);
       sb.append(".");

--- a/src/main/java/com/avaje/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -417,7 +417,7 @@ public class SqlTreeBuilder {
     // This makes sense for transient properties used to
     // hold sum() count() type values (with SqlSelect)
     for (String propName : queryProps.getSelectProperties()) {
-      if (propName.length() > 0) {
+      if (!propName.isEmpty()) {
         addProperty(selectProps, desc, queryProps, propName);
       }
     }

--- a/src/main/java/com/avaje/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -522,7 +522,7 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
       List<SpiExpression> exprList = whereExpressions.internalList();
       if (exprList.size() > 1) {
         return null;
-      } else if (exprList.size() == 0) {
+      } else if (exprList.isEmpty()) {
         return namedBind;
       } else {
         if (namedBind != null) {
@@ -1151,7 +1151,7 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
 
   @Override
   public DefaultOrmQuery<T> order(String orderByClause) {
-    if (orderByClause == null || orderByClause.trim().length() == 0) {
+    if (orderByClause == null || orderByClause.trim().isEmpty()) {
       this.orderBy = null;
     } else {
       this.orderBy = new OrderBy<T>(this, orderByClause);

--- a/src/main/java/com/avaje/ebeaninternal/server/querydefn/OrmQueryDetail.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/querydefn/OrmQueryDetail.java
@@ -198,7 +198,7 @@ public class OrmQueryDetail implements Serializable {
       }
     }
 
-    if (matchingPaths.size() == 0) {
+    if (matchingPaths.isEmpty()) {
       return null;
     }
 

--- a/src/main/java/com/avaje/ebeaninternal/server/querydefn/OrmQueryDetailParser.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/querydefn/OrmQueryDetailParser.java
@@ -134,7 +134,7 @@ public class OrmQueryDetailParser {
       }
     }
     String whereClause = sb.toString().trim();
-    if (whereClause.length() > 0) {
+    if (!whereClause.isEmpty()) {
       rawWhereClause = whereClause;
     }
 

--- a/src/main/java/com/avaje/ebeaninternal/server/querydefn/OrmQueryProperties.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/querydefn/OrmQueryProperties.java
@@ -236,7 +236,7 @@ public class OrmQueryProperties implements Serializable {
   @SuppressWarnings("unchecked")
   public void configureBeanQuery(SpiQuery<?> query) {
 
-    if (trimmedProperties != null && trimmedProperties.length() > 0) {
+    if (trimmedProperties != null && !trimmedProperties.isEmpty()) {
       query.select(trimmedProperties);
     }
 

--- a/src/main/java/com/avaje/ebeaninternal/server/querydefn/OrmQueryPropertiesParser.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/querydefn/OrmQueryPropertiesParser.java
@@ -122,7 +122,7 @@ public class OrmQueryPropertiesParser {
     String temp;
     for (int i = 0; i < res.length; i++) {
       temp = res[i].trim();
-      if (temp.length() > 0) {
+      if (!temp.isEmpty()) {
         if (count > 0) {
           sb.append(",");
         }

--- a/src/main/java/com/avaje/ebeaninternal/server/text/csv/TCsvReader.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/text/csv/TCsvReader.java
@@ -268,7 +268,7 @@ public class TCsvReader<T> implements CsvReader<T> {
 
 		strValue = strValue.trim();
 
-		if (strValue.length() == 0) {
+		if (strValue.isEmpty()) {
 			return;
 		}
 

--- a/src/main/java/com/avaje/ebeaninternal/server/type/ScalarTypeChar.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/type/ScalarTypeChar.java
@@ -35,7 +35,7 @@ public class ScalarTypeChar extends ScalarTypeBaseVarchar<Character> {
 
   public Character read(DataReader dataReader) throws SQLException {
     String string = dataReader.getString();
-    if (string == null || string.length() == 0) {
+    if (string == null || string.isEmpty()) {
       return null;
     } else {
       return string.charAt(0);

--- a/src/main/java/com/avaje/ebeaninternal/server/util/BindParamsParser.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/util/BindParamsParser.java
@@ -86,7 +86,7 @@ public class BindParamsParser {
 
     if (params.isSameBindHash()) {
       String preparedSql = params.getPreparedSql();
-      if (preparedSql != null && preparedSql.length() > 0) {
+      if (preparedSql != null && !preparedSql.isEmpty()) {
         // the sql has already been parsed and positionedParameters are set in order
         return preparedSql;
       }

--- a/src/main/java/com/avaje/ebeaninternal/util/SortByClauseParser.java
+++ b/src/main/java/com/avaje/ebeaninternal/util/SortByClauseParser.java
@@ -33,7 +33,7 @@ public final class SortByClauseParser {
   }
 
   private Property parseSection(String section) {
-    if (section.length() == 0) {
+    if (section.isEmpty()) {
       return null;
     }
     String[] words = section.split(" ");

--- a/src/main/java/com/avaje/ebeanservice/docstore/api/support/DocStoreBeanBaseAdapter.java
+++ b/src/main/java/com/avaje/ebeanservice/docstore/api/support/DocStoreBeanBaseAdapter.java
@@ -321,7 +321,7 @@ public abstract class DocStoreBeanBaseAdapter<T> implements DocStoreBeanAdapter<
    * Return the supplied value or default to the bean name lower case.
    */
   protected String derive(BeanType<?> desc, String suppliedValue) {
-    return (suppliedValue != null && suppliedValue.length() > 0) ? suppliedValue : desc.getName().toLowerCase();
+    return (suppliedValue != null && !suppliedValue.isEmpty()) ? suppliedValue : desc.getName().toLowerCase();
   }
 
   @Override

--- a/src/test/java/com/avaje/ebean/PrimaryServerTest.java
+++ b/src/test/java/com/avaje/ebean/PrimaryServerTest.java
@@ -30,6 +30,6 @@ public class PrimaryServerTest {
   public void testLoadProperties() throws Exception {
 
     Properties properties = PrimaryServer.getProperties();
-    assertTrue(properties.size() > 0);
+    assertTrue(!properties.isEmpty());
   }
 }

--- a/src/test/java/com/avaje/tests/basic/TestFetchId.java
+++ b/src/test/java/com/avaje/tests/basic/TestFetchId.java
@@ -41,6 +41,6 @@ public class TestFetchId extends BaseTestCase {
 		List<Object> idList = futureIds.get();
 		Assert.assertTrue("same instance", partial == idList);
 
-		Assert.assertTrue("sz > 0", ids.size() > 0);
+		Assert.assertTrue("sz > 0", !ids.isEmpty());
 	}
 }

--- a/src/test/java/com/avaje/tests/basic/TestInheritRef.java
+++ b/src/test/java/com/avaje/tests/basic/TestInheritRef.java
@@ -34,7 +34,7 @@ public class TestInheritRef extends BaseTestCase {
               .setAutoTune(false)
               .findList();
 
-      Assert.assertTrue(list.size() > 0);
+      Assert.assertTrue(!list.isEmpty());
 
       Truck foundTruck = null;
       int found = 0;

--- a/src/test/java/com/avaje/tests/basic/TestLazyLoadInCache.java
+++ b/src/test/java/com/avaje/tests/basic/TestLazyLoadInCache.java
@@ -29,7 +29,7 @@ public class TestLazyLoadInCache extends BaseTestCase {
 			.orderBy().asc("id")
 			.findMap();
 		
-		assertTrue(map.size() > 0);
+		assertTrue(!map.isEmpty());
 		
 		Object id = map.keySet().iterator().next();
 		

--- a/src/test/java/com/avaje/tests/basic/TestLimitQuery.java
+++ b/src/test/java/com/avaje/tests/basic/TestLimitQuery.java
@@ -101,7 +101,7 @@ public class TestLimitQuery extends BaseTestCase {
 
     List<Order> list = query.findList();
 
-    Assert.assertTrue("sz > 0", list.size() > 0);
+    Assert.assertTrue("sz > 0", !list.isEmpty());
 
     String sql = query.getGeneratedSql();
     boolean hasDetailsJoin = sql.contains("join o_order_detail");

--- a/src/test/java/com/avaje/tests/basic/TestM2MVanilla.java
+++ b/src/test/java/com/avaje/tests/basic/TestM2MVanilla.java
@@ -76,7 +76,7 @@ public class TestM2MVanilla extends BaseTestCase {
     Query<MUser> rolesQuery = Ebean.find(MUser.class).where().in("roles", roleList).query();
 
     List<MUser> userInRolesList = rolesQuery.findList();
-    Assert.assertTrue(userInRolesList.size() > 0);
+    Assert.assertTrue(!userInRolesList.isEmpty());
 
     List<MUser> list = Ebean.find(MUser.class)
         .where().in("roles", roleList)

--- a/src/test/java/com/avaje/tests/basic/TestManyLazyLoad.java
+++ b/src/test/java/com/avaje/tests/basic/TestManyLazyLoad.java
@@ -24,7 +24,7 @@ public class TestManyLazyLoad extends BaseTestCase {
     awaitL2Cache();
 
     List<Order> list = Ebean.find(Order.class).order().asc("id").findList();
-    assertTrue(list.size() + " > 0", list.size() > 0);
+    assertTrue(list.size() + " > 0", !list.isEmpty());
 
     // just use the first one
     Order order = list.get(0);

--- a/src/test/java/com/avaje/tests/basic/TestOrderByAnnotation.java
+++ b/src/test/java/com/avaje/tests/basic/TestOrderByAnnotation.java
@@ -23,7 +23,7 @@ public class TestOrderByAnnotation extends BaseTestCase {
 		Customer customer = Ebean.find(Customer.class, custTest.getId());
 		List<Order> orders = customer.getOrders();
 
-		Assert.assertTrue(orders.size() > 0);
+		Assert.assertTrue(!orders.isEmpty());
 
 
 		Query<Order> q1 = Ebean.find(Order.class)

--- a/src/test/java/com/avaje/tests/basic/TestReadOnlyPropagation.java
+++ b/src/test/java/com/avaje/tests/basic/TestReadOnlyPropagation.java
@@ -47,7 +47,7 @@ public class TestReadOnlyPropagation extends BaseTestCase {
 		Assert.assertTrue(!bc.isPopulated());
 		
 		bc.size();
-		Assert.assertTrue(bc.size() > 0);
+		Assert.assertTrue(!bc.isEmpty());
 		Assert.assertTrue(bc.isReadOnly());
 		Assert.assertTrue(bc.isPopulated());
 		try {

--- a/src/test/java/com/avaje/tests/basic/TestSharedInstancePropagation.java
+++ b/src/test/java/com/avaje/tests/basic/TestSharedInstancePropagation.java
@@ -47,7 +47,7 @@ public class TestSharedInstancePropagation extends BaseTestCase {
 		bc.size();
 		
 		assertTrue(bc.isPopulated());
-		assertTrue(bc.size() > 0);
+		assertTrue(!bc.isEmpty());
 		OrderDetail detail = details.get(0);
 		
 		assertTrue(Ebean.getBeanState(detail).isReadOnly());

--- a/src/test/java/com/avaje/tests/basic/TestWhereAnnotation.java
+++ b/src/test/java/com/avaje/tests/basic/TestWhereAnnotation.java
@@ -23,7 +23,7 @@ public class TestWhereAnnotation extends BaseTestCase {
     Customer customer = Ebean.find(Customer.class, custTest.getId());
     List<Order> orders = customer.getOrders();
 
-    Assert.assertTrue(orders.size() > 0);
+    Assert.assertTrue(!orders.isEmpty());
 
     Query<Customer> q1 = Ebean.find(Customer.class).setUseCache(false).fetch("orders").where()
         .idEq(1).query();

--- a/src/test/java/com/avaje/tests/batchload/TestBasicLazy.java
+++ b/src/test/java/com/avaje/tests/batchload/TestBasicLazy.java
@@ -48,7 +48,7 @@ public class TestBasicLazy extends BaseTestCase {
     // some contacts
     Customer c = Ebean.find(Customer.class).setId(1).findUnique();
     Assert.assertNotNull(c.getContacts());
-    Assert.assertTrue("no contacts on test customer 1", c.getContacts().size() > 0);
+    Assert.assertTrue("no contacts on test customer 1", !c.getContacts().isEmpty());
 
     // start transaction so we have a "long running" persistence context
     Transaction tx = Ebean.beginTransaction();
@@ -56,7 +56,7 @@ public class TestBasicLazy extends BaseTestCase {
       List<Order> order = Ebean.find(Order.class).where(Expr.eq("customer.id", 1)).findList();
 
       Assert.assertNotNull(order);
-      Assert.assertTrue(order.size() > 0);
+      Assert.assertTrue(!order.isEmpty());
 
       Customer customer = order.get(0).getCustomer();
       Assert.assertNotNull(customer);
@@ -66,7 +66,7 @@ public class TestBasicLazy extends BaseTestCase {
       List<Contact> contacts = customer.getContacts();
 
       Assert.assertNotNull(contacts);
-      Assert.assertTrue("contacts not lazily fetched", contacts.size() > 0);
+      Assert.assertTrue("contacts not lazily fetched", !contacts.isEmpty());
     } finally {
       tx.commit();
     }
@@ -196,7 +196,7 @@ public class TestBasicLazy extends BaseTestCase {
       MyTestDataSourcePoolListener.SLEEP_AFTER_BORROW = 0;
     }
 
-    if (exceptions.size() > 0) {
+    if (!exceptions.isEmpty()) {
       System.err.println("Seen Exceptions:");
       for (Throwable exception : exceptions) {
         exception.printStackTrace();

--- a/src/test/java/com/avaje/tests/batchload/TestLazyJoin2.java
+++ b/src/test/java/com/avaje/tests/batchload/TestLazyJoin2.java
@@ -35,7 +35,7 @@ public class TestLazyJoin2 extends BaseTestCase {
     Order o0 = l0.get(0);
     Customer c0 = o0.getCustomer();
     List<Contact> contacts = c0.getContacts();
-    Assert.assertTrue(contacts.size() > 0);
+    Assert.assertTrue(!contacts.isEmpty());
 
     // query 1) find order (status, shipDate)
     // query 2) find orderDetail (quantity, price) join product (sku, name)

--- a/src/test/java/com/avaje/tests/batchload/TestQueryJoin.java
+++ b/src/test/java/com/avaje/tests/batchload/TestQueryJoin.java
@@ -60,7 +60,7 @@ public class TestQueryJoin extends BaseTestCase {
     System.out.println(billingAddress);
     billingAddress.getLine1();
 
-    Assert.assertTrue(list.size() > 0);
+    Assert.assertTrue(!list.isEmpty());
 
   }
 }

--- a/src/test/java/com/avaje/tests/batchload/TestSecondaryQueries.java
+++ b/src/test/java/com/avaje/tests/batchload/TestSecondaryQueries.java
@@ -68,7 +68,7 @@ public class TestSecondaryQueries extends BaseTestCase {
     spiQuery.setLogSecondaryQuery(true);
     
     List<Order> list = query.findList();
-    Assert.assertTrue(list.size() > 0);
+    Assert.assertTrue(!list.isEmpty());
     for (Order order : list) {
       order.getCustomer().getStatus();
     }

--- a/src/test/java/com/avaje/tests/cache/TestQueryCache.java
+++ b/src/test/java/com/avaje/tests/cache/TestQueryCache.java
@@ -29,7 +29,7 @@ public class TestQueryCache extends BaseTestCase {
     BeanCollection<Customer> bc = (BeanCollection<Customer>) list;
     Assert.assertFalse(bc.isReadOnly());
     Assert.assertFalse(bc.isEmpty());
-    Assert.assertTrue(list.size() > 0);
+    Assert.assertTrue(!list.isEmpty());
     Assert.assertTrue(Ebean.getBeanState(list.get(0)).isReadOnly());
 
     List<Customer> list2 = Ebean.find(Customer.class).setUseQueryCache(true).setReadOnly(true).where()

--- a/src/test/java/com/avaje/tests/cache/TestQueryCacheCountry.java
+++ b/src/test/java/com/avaje/tests/cache/TestQueryCacheCountry.java
@@ -38,7 +38,7 @@ public class TestQueryCacheCountry extends BaseTestCase {
       .findList();
     
     assertEquals(1, queryCache.getStatistics(false).getSize());
-    assertTrue(countryList0.size() > 0);
+    assertTrue(!countryList0.isEmpty());
     
     List<Country> countryList1 = Ebean.find(Country.class)
         .setUseQueryCache(true)

--- a/src/test/java/com/avaje/tests/inheritance/company/domain/TestInheritAbstract.java
+++ b/src/test/java/com/avaje/tests/inheritance/company/domain/TestInheritAbstract.java
@@ -38,7 +38,7 @@ public class TestInheritAbstract extends TestCase {
 		.findList();
 	
 		Assert.assertNotNull(list2);
-		Assert.assertTrue(list2.size() > 0);
+		Assert.assertTrue(!list2.isEmpty());
 		
 		for (AbstractBar abstractBar : list2) {
 			Foo foo = abstractBar.getFoo();

--- a/src/test/java/com/avaje/tests/query/TestLimitQuery.java
+++ b/src/test/java/com/avaje/tests/query/TestLimitQuery.java
@@ -24,7 +24,7 @@ public class TestLimitQuery extends BaseTestCase {
             .findList();
 
     // should at least find the "Cust NoAddress" customer
-    Assert.assertTrue(customers.size() > 0);
+    Assert.assertTrue(!customers.isEmpty());
 
   }
 }

--- a/src/test/java/com/avaje/tests/query/TestQueryFetchManyTwoDeep.java
+++ b/src/test/java/com/avaje/tests/query/TestQueryFetchManyTwoDeep.java
@@ -31,7 +31,7 @@ public class TestQueryFetchManyTwoDeep extends BaseTestCase {
     spiQuery.setLogSecondaryQuery(true);
     
     List<Customer> list = query.findList();
-    Assert.assertTrue("has rows", list.size() > 0);
+    Assert.assertTrue("has rows", !list.isEmpty());
     Assert.assertTrue(query.getGeneratedSql().contains("from o_customer t0 "));
     Assert.assertTrue(query.getGeneratedSql().contains("left outer join o_order t1 on t1.kcustomer_id = t0.id"));
     Assert.assertTrue(query.getGeneratedSql().contains("left outer join o_customer t2 on t2.id = t1.kcustomer_id"));
@@ -71,7 +71,7 @@ public class TestQueryFetchManyTwoDeep extends BaseTestCase {
         .fetch("order.details");
 
     List<OrderShipment> shipList = shipQuery.findList();
-    Assert.assertTrue("has rows", shipList.size() > 0);
+    Assert.assertTrue("has rows", !shipList.isEmpty());
     
     String generatedSql = shipQuery.getGeneratedSql();
 
@@ -112,7 +112,7 @@ public class TestQueryFetchManyTwoDeep extends BaseTestCase {
         .fetch("customer.orders");
 
     List<Contact> shipList = query.findList();
-    Assert.assertTrue("has rows", shipList.size() > 0);
+    Assert.assertTrue("has rows", !shipList.isEmpty());
     
     String generatedSql = query.getGeneratedSql();
 
@@ -144,7 +144,7 @@ public class TestQueryFetchManyTwoDeep extends BaseTestCase {
         .query();
 
     List<Contact> list = query.findList();
-    Assert.assertTrue("has rows", list.size() > 0);
+    Assert.assertTrue("has rows", !list.isEmpty());
     
     String generatedSql = query.getGeneratedSql();
 

--- a/src/test/java/com/avaje/tests/query/TestQueryMultiManyOrder.java
+++ b/src/test/java/com/avaje/tests/query/TestQueryMultiManyOrder.java
@@ -24,7 +24,7 @@ public class TestQueryMultiManyOrder extends BaseTestCase {
     List<Order> list = q.findList();
     String sql = q.getGeneratedSql();
 
-    Assert.assertTrue(list.size() > 0);
+    Assert.assertTrue(!list.isEmpty());
     Assert.assertTrue(sql.contains("join o_customer "));
 
     Assert.assertFalse(sql.contains("left outer join contact "));

--- a/src/test/java/com/avaje/tests/query/TestQueryPlanCacheRowCount.java
+++ b/src/test/java/com/avaje/tests/query/TestQueryPlanCacheRowCount.java
@@ -39,7 +39,7 @@ public class TestQueryPlanCacheRowCount extends BaseTestCase {
     Assert.assertEquals(rc0, list1.size());
 
     int idGt = 5;
-    if (ids1.size() > 0) {
+    if (!ids1.isEmpty()) {
       Object id = ids.get(0);
       idGt = Integer.valueOf("" + id);
     }

--- a/src/test/java/com/avaje/tests/query/joins/TestQueryJoinManyNonRoot.java
+++ b/src/test/java/com/avaje/tests/query/joins/TestQueryJoinManyNonRoot.java
@@ -48,7 +48,7 @@ public class TestQueryJoinManyNonRoot extends BaseTestCase {
     List<Order> list = q.findList();
     String sql = q.getGeneratedSql();
 
-    assertTrue(list.size() > 0);
+    assertTrue(!list.isEmpty());
     assertTrue(sql.contains("join o_customer t1 on t1.id "));
     assertTrue(sql.contains("left outer join contact t2 on"));
     
@@ -77,7 +77,7 @@ public class TestQueryJoinManyNonRoot extends BaseTestCase {
     List<Order> list = q.findList();
     String sql = q.getGeneratedSql();
 
-    assertTrue(list.size() > 0);
+    assertTrue(!list.isEmpty());
     assertTrue(sql.contains("join o_customer t1 on t1.id "));
     assertTrue(sql.contains("left outer join o_order_detail "));
     assertTrue(sql.contains("left outer join o_product "));
@@ -105,7 +105,7 @@ public class TestQueryJoinManyNonRoot extends BaseTestCase {
       order.getCustomer().getContacts().size();
     }
 
-    assertTrue(list.size() > 0);
+    assertTrue(!list.isEmpty());
     assertTrue(sql.contains("join o_customer t1 on t1.id "));
     assertTrue(sql.contains("left outer join contact "));
 

--- a/src/test/java/com/avaje/tests/query/joins/TestQueryJoinQueryNonRoot.java
+++ b/src/test/java/com/avaje/tests/query/joins/TestQueryJoinQueryNonRoot.java
@@ -35,7 +35,7 @@ public class TestQueryJoinQueryNonRoot extends BaseTestCase {
         .where().lt("id", 3).findList();
 
     Assert.assertNotNull(list);
-    Assert.assertTrue(list.size() > 0);
+    Assert.assertTrue(!list.isEmpty());
 
     for (Order order : list) {
       List<Contact> contacts = order.getCustomer().getContacts();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1155 - "Collection.isEmpty() should be used to test for emptiness".
You can find more information about the issue here:
https://sonar.spring.io/coding_rules#rule_key=squid:S1155
Please let me know if you have any questions.
Artyom Melnikov