### PR TITLE
Example code typo

### DIFF
--- a/src/main/java/com/avaje/ebean/SqlUpdate.java
+++ b/src/main/java/com/avaje/ebean/SqlUpdate.java
@@ -26,7 +26,7 @@ package com.avaje.ebean;
  * 
  * int modifiedCount = Ebean.execute(update);
  * 
- * String msg = &quot;There where &quot; + modifiedCount + &quot;rows updated&quot;
+ * String msg = &quot;There were &quot; + modifiedCount + &quot; rows updated&quot;
  * </pre>
  * 
  * @see Update


### PR DESCRIPTION
Change "there where" to "there were" and add space between modify count and next word.