### PR TITLE
FIX: PathTests - on Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,13 +69,13 @@
     <dependency>
       <groupId>org.avaje</groupId>
       <artifactId>avaje-classpath-scanner-api</artifactId>
-      <version>2.1</version>
+      <version>2.2-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.avaje</groupId>
       <artifactId>avaje-classpath-scanner</artifactId>
-      <version>2.1.1</version>
+      <version>2.1.2-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/test/java/com/avaje/ebeaninternal/server/type/ScalarTypePathTest.java
+++ b/src/test/java/com/avaje/ebeaninternal/server/type/ScalarTypePathTest.java
@@ -2,21 +2,23 @@ package com.avaje.ebeaninternal.server.type;
 
 import org.junit.Test;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 
 public class ScalarTypePathTest {
-
+  private static final String TEMP_PATH = new File("/tmp").getAbsolutePath();
+  
   private ScalarTypePath type = new ScalarTypePath();
   
   @Test
   public void convertFromDbString() throws Exception {
 
-    Path path = Paths.get("/tmp");
+    Path path = Paths.get(TEMP_PATH);
 
-    String asString = type.convertToDbString(path);
+    String asString = type.convertToDbString(path); // "/tmp" will be converted to "file://c:/tmp" on windows
     Path converted = type.convertFromDbString(asString);
 
     assertEquals(path, converted);
@@ -25,7 +27,7 @@ public class ScalarTypePathTest {
   @Test
   public void formatAndParse() throws Exception {
 
-    Path path = Paths.get("/tmp");
+    Path path = Paths.get(TEMP_PATH);
 
     String asString = type.formatValue(path);
     Path converted = type.parse(asString);

--- a/src/test/java/com/avaje/tests/types/TestNewTypes.java
+++ b/src/test/java/com/avaje/tests/types/TestNewTypes.java
@@ -5,6 +5,7 @@ import com.avaje.ebean.Ebean;
 import com.avaje.tests.model.types.SomeNewTypesBean;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.time.*;
@@ -16,6 +17,7 @@ import static org.junit.Assert.assertTrue;
 
 public class TestNewTypes extends BaseTestCase {
 
+  private static final String TEMP_PATH = new File("/tmp").getAbsolutePath();	
   @Test
   public void testInsertUpdate() throws IOException {
 
@@ -31,7 +33,7 @@ public class TestNewTypes extends BaseTestCase {
     bean.setZoneId(ZoneId.systemDefault());
     bean.setZoneOffset(ZonedDateTime.now().getOffset());
     bean.setYearMonth(YearMonth.of(2014, 9));
-    bean.setPath(Paths.get("/tmp"));
+    bean.setPath(Paths.get(TEMP_PATH));
 
 
     Ebean.save(bean);
@@ -71,7 +73,7 @@ public class TestNewTypes extends BaseTestCase {
     list = Ebean.find(SomeNewTypesBean.class).where().le("month", Month.SEPTEMBER).findList();
     assertTrue(!list.isEmpty());
 
-    list = Ebean.find(SomeNewTypesBean.class).where().eq("path", Paths.get("/tmp")).findList();
+    list = Ebean.find(SomeNewTypesBean.class).where().eq("path", Paths.get(TEMP_PATH)).findList();
     assertTrue(!list.isEmpty());
 
     SomeNewTypesBean fetched = Ebean.find(SomeNewTypesBean.class, bean.getId());
@@ -100,6 +102,7 @@ public class TestNewTypes extends BaseTestCase {
     assertEquals(bean.getLocalDateTime(), toBean.getLocalDateTime());
     assertEquals(bean.getOffsetDateTime(), toBean.getOffsetDateTime());
     assertEquals(bean.getInstant(), toBean.getInstant());
+    // FIXME: This test fails on Windows with: expected:<\tmp> but was:<C:\tmp>
     assertEquals(bean.getPath(), toBean.getPath());
 
   }


### PR DESCRIPTION
they fail on windows machine because the OS translates "/tmp" to "c:\tmp". bumped classpath-canner to next SNAPSHOT API version (see other pull requests)